### PR TITLE
Actualizar cuestionario con banco de termodinámica

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Test interactivo de Frontend</title>
+  <title>Evaluación interactiva de termodinámica</title>
   <style>
     :root {
       --bg-gradient-start: #f5f7ff;
@@ -368,6 +368,7 @@
       font-weight: 600;
       color: var(--text);
       min-width: 130px;
+      flex: 1 1 260px;
     }
 
     .match-answer {
@@ -396,6 +397,63 @@
       border-color: var(--error);
       background: var(--error-bg);
       box-shadow: 0 18px 45px -32px rgba(239, 68, 68, 0.35);
+    }
+
+    .group-tf-row {
+      align-items: flex-start;
+    }
+
+    .group-tf-controls {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-left: auto;
+    }
+
+    .group-tf-option {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-weight: 600;
+      color: var(--text);
+      background: #f8fafc;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      padding: 0.35rem 0.75rem;
+      cursor: pointer;
+      transition: background 0.2s ease, border 0.2s ease, color 0.2s ease;
+    }
+
+    .group-tf-option:hover {
+      border-color: var(--primary);
+    }
+
+    .group-tf-option input {
+      accent-color: var(--primary);
+    }
+
+    .group-tf-option.is-active {
+      border-color: var(--primary);
+      background: rgba(99, 102, 241, 0.15);
+      color: var(--primary-dark);
+    }
+
+    .group-tf-option.is-correct,
+    .group-tf-option.show-correct {
+      border-color: var(--success);
+      background: var(--success-bg);
+      color: #047857;
+    }
+
+    .group-tf-option.is-incorrect {
+      border-color: var(--error);
+      background: var(--error-bg);
+      color: #b91c1c;
+    }
+
+    .group-tf-row.is-locked .group-tf-option {
+      cursor: default;
+      opacity: 0.95;
     }
 
     .feedback-area {
@@ -600,13 +658,19 @@
       .nav-btn {
         flex: 1;
       }
+
+      .group-tf-controls {
+        width: 100%;
+        margin-left: 0;
+        justify-content: flex-start;
+      }
     }
   </style>
 </head>
 <body>
   <main class="app">
     <header class="app-header">
-      <h1>Evaluación interactiva de desarrollo frontend</h1>
+      <h1>Evaluación interactiva de termodinámica y diseño de ingeniería</h1>
       <p>Respondé las preguntas y obtené retroalimentación inmediata. Podés navegar por el resumen, y tu progreso se guardará automáticamente en este dispositivo.</p>
     </header>
     <div class="layout">
@@ -634,93 +698,443 @@
     </section>
   </main>
   <script>
-    const questions = [
+    const QUESTIONS = [
       {
-        id: 'q1',
-        type: 'single',
-        title: '¿Qué etiqueta HTML semántica representa el contenido principal de una página?',
-        helper: 'Elegí la opción correcta.',
-        options: [
-          { value: 'div', label: '<div>' },
-          { value: 'main', label: '<main>' },
-          { value: 'section', label: '<section>' },
-          { value: 'article', label: '<article>' }
-        ],
-        correct: ['main'],
-        explanation: 'La etiqueta <main> describe el contenido central del documento. Ayuda a los lectores de pantalla a saltar directamente al contenido principal y mejora la estructura semántica.'
-      },
-      {
-        id: 'q2',
+        id: 1,
         type: 'multi',
-        title: '¿Qué prácticas mejoran la accesibilidad de una interfaz web?',
-        helper: 'Podés elegir más de una opción. La corrección se mostrará automáticamente un instante después de tu última selección.',
-        options: [
-          { value: 'contrast', label: 'Mantener un contraste suficiente entre el texto y el fondo.' },
-          { value: 'semanticless', label: 'Usar únicamente contenedores <div> sin etiquetas semánticas.' },
-          { value: 'labels', label: 'Asociar etiquetas <label> con sus controles de formulario.' },
-          { value: 'coloronly', label: 'Comunicar estados solo mediante el color.' }
-        ],
-        correct: ['contrast', 'labels'],
-        explanation: 'Un contraste adecuado y las etiquetas asociadas permiten que más personas perciban y comprendan la interfaz. Depender solo de <div> o del color dificulta el uso con tecnologías de asistencia.'
+        prompt: 'Seleccionar cuáles son los modos de transferencia de energía en termodinámica:',
+        options: ['Energía Potencial', 'Trabajo', 'Energía Cinética', 'Energía Interna', 'Entropía', 'Calor'],
+        correct: [1, 5],
+        explanation: 'En termodinámica, la energía se transfiere como trabajo o como calor; las demás son formas almacenadas o propiedades.'
       },
       {
-        id: 'q3',
+        id: 2,
+        type: 'multi',
+        prompt: 'Seleccionar cuáles son los modos de transferencia de calor:',
+        options: ['Radiación', 'Convección', 'Evaporación', 'Fusión', 'Conducción'],
+        correct: [0, 1, 4],
+        explanation: 'Los mecanismos fundamentales de transferencia de calor son conducción, convección y radiación.'
+      },
+      {
+        id: 3,
         type: 'tf',
-        title: 'Las media queries de CSS permiten adaptar los estilos a distintos tamaños de pantalla.',
-        helper: 'Seleccioná Verdadero o Falso.',
-        options: [
-          { value: 'true', label: 'Verdadero' },
-          { value: 'false', label: 'Falso' }
-        ],
-        correct: ['true'],
-        explanation: 'Las media queries consultan las características del dispositivo (como el ancho de la pantalla) y permiten definir estilos específicos para cada caso, haciendo el diseño responsive.'
+        prompt: 'Según el convenio de signos, Q > 0 cuando el calor entra al sistema.',
+        correct: true,
+        explanation: 'Por convenio clásico, Q>0 hacia el sistema y Q<0 desde el sistema.'
       },
       {
-        id: 'q4',
+        id: 4,
+        type: 'multi',
+        prompt: 'Ciclos utilizados solo en motores de combustión externa:',
+        options: ['Ciclo Diésel', 'Ciclo Rankine', 'Ciclo Brayton', 'Ciclo Otto'],
+        correct: [1],
+        explanation: 'El ciclo Rankine (máquinas de vapor) es de combustión externa en su configuración típica.'
+      },
+      {
+        id: 5,
         type: 'match',
-        title: 'Emparejá cada técnica de rendimiento con su descripción.',
-        helper: 'Elegí una definición para cada concepto.',
-        pairs: [
-          {
-            left: 'Lazy loading',
-            options: [
-              { value: 'defer', label: 'Cargar recursos solo cuando realmente son necesarios.' },
-              { value: 'cache', label: 'Almacenar archivos en el navegador para futuras visitas.' },
-              { value: 'minify', label: 'Eliminar espacios y caracteres innecesarios del código.' }
-            ],
-            correct: 'defer'
-          },
-          {
-            left: 'Caching',
-            options: [
-              { value: 'compress', label: 'Comprimir recursos estáticos para reducir su peso.' },
-              { value: 'cache', label: 'Almacenar archivos en el navegador para futuras visitas.' },
-              { value: 'defer', label: 'Cargar recursos solo cuando realmente son necesarios.' }
-            ],
-            correct: 'cache'
-          },
-          {
-            left: 'Minificación',
-            options: [
-              { value: 'minify', label: 'Eliminar espacios y caracteres innecesarios del código.' },
-              { value: 'compress', label: 'Comprimir recursos estáticos para reducir su peso.' },
-              { value: 'cache', label: 'Almacenar archivos en el navegador para futuras visitas.' }
-            ],
-            correct: 'minify'
-          }
+        prompt: 'Emparejar cada principio con su definición:',
+        left: [
+          'Transferir calor de un cuerpo frío a uno caliente como único efecto es imposible.',
+          'No existe ciclo que convierta íntegramente el calor absorbido en trabajo.',
+          'Relación entre calor, trabajo y energía interna en un sistema.'
         ],
-        explanation: 'Cada técnica aborda un aspecto diferente del rendimiento: el lazy loading retrasa la carga, el caching guarda recursos ya descargados y la minificación reduce el tamaño del código.'
+        right: [
+          'Formulación de Clausius',
+          'Enunciado de Kelvin–Planck',
+          'Principio de conservación de la energía'
+        ],
+        correct: [0, 1, 2],
+        explanation: 'Clausius prohíbe transferencia espontánea de frío a caliente; Kelvin–Planck prohíbe la conversión total de Q en W; el primero es la 1ª Ley.'
+      },
+      {
+        id: 6,
+        type: 'multi',
+        prompt: 'Componentes principales de un motor de turbina de gas de ciclo abierto:',
+        options: ['Cámara de combustión', 'Filtro', 'Turbina', 'Compresor', 'Trampa de agua', 'Bomba'],
+        correct: [0, 2, 3],
+        explanation: 'Las tres etapas básicas: compresor, combustor, turbina.'
+      },
+      {
+        id: 7,
+        type: 'single',
+        prompt: '¿Cuál curva corresponde a un ciclo de Carnot?',
+        options: ['Dos isotermas y dos isobaras', 'Dos isobaras y dos adiabáticas', 'Dos isotermas y dos isocoras', 'Dos isotermas y dos adiabáticas'],
+        correct: 3,
+        explanation: 'Carnot se compone de dos procesos isotermos y dos adiabáticos reversibles.'
+      },
+      {
+        id: 8,
+        type: 'multi',
+        prompt: 'Seleccione cuáles son etapas de diseño en ingeniería:',
+        options: [
+          'Identificar alternativas realizables',
+          'Determinar restricciones y criterios',
+          'Elegir la solución solo por menor costo',
+          'Definir objetivos del diseño',
+          'Concretar especificaciones cualitativas'
+        ],
+        correct: [0, 1, 3, 4],
+        explanation: 'Elegir solo por costo ignora criterios esenciales del diseño.'
+      },
+      {
+        id: 9,
+        type: 'tf',
+        prompt: 'El rendimiento de un ciclo Ericsson ideal es el mismo que el de Carnot.',
+        correct: true,
+        explanation: 'Con regeneración ideal e isotermas, Ericsson alcanza la eficiencia de Carnot.'
+      },
+      {
+        id: 10,
+        type: 'match',
+        prompt: 'Metodología: emparejar cada paso con su definición.',
+        left: [
+          'Establecer con tus palabras lo que debe calcularse.',
+          'Listar consideraciones e idealizaciones.',
+          'Establecer brevemente lo que es conocido.',
+          'Dibujar el esquema y rotular datos.',
+          'Expresar ecuaciones y relaciones y resolver.'
+        ],
+        right: [
+          'Determinar lo que se debe hallar',
+          'Establecer consideraciones e hipótesis',
+          'Determinar lo conocido',
+          'Determinar los datos y diagramas',
+          'Realizar el análisis'
+        ],
+        correct: [0, 1, 2, 3, 4],
+        explanation: 'Corresponde al flujo clásico de resolución de problemas en ingeniería.'
+      },
+      {
+        id: 11,
+        type: 'match',
+        prompt: 'Ordenar los pasos (1→5).',
+        left: [
+          'Paso 5. Realizar el análisis.',
+          'Paso 4. Establecer consideraciones e hipótesis.',
+          'Paso 3. Determinar los diagramas y datos.',
+          'Paso 2. Determinar lo que se debe hallar.',
+          'Paso 1. Determinar lo conocido.'
+        ],
+        right: ['1', '2', '3', '4', '5'],
+        correct: [4, 3, 2, 1, 0],
+        explanation: 'Secuencia lógica del método propuesto.'
+      },
+      {
+        id: 12,
+        type: 'multi',
+        prompt: 'Ejemplos de restricción en diseño y análisis:',
+        options: ['Estándares de seguridad', 'Estética final', 'Estándares ambientales', 'Costos'],
+        correct: [0, 2, 3],
+        explanation: 'Seguridad, ambiente y costos suelen figurar como restricciones; la estética es criterio pero no siempre una restricción dura.'
+      },
+      {
+        id: 13,
+        type: 'tf',
+        prompt: 'Un flujo unidimensional es un flujo de materia que entra o sale de un volumen de control.',
+        correct: false,
+        explanation: '1D describe variación principal en una sola dirección; lo otro describe un sistema abierto.'
+      },
+      {
+        id: 14,
+        type: 'single',
+        prompt: '¿En qué componente la velocidad del fluido disminuye en la dirección del flujo?',
+        options: ['Difusor', 'Compresor', 'Intercambiador de calor', 'Bomba', 'Tobera'],
+        correct: 0,
+        explanation: 'El difusor ensancha el área y reduce la velocidad aumentando la presión.'
+      },
+      {
+        id: 15,
+        type: 'tf',
+        prompt: 'Una turbomáquina donde "se produce calor" al pasar un fluido por álabes solidarios a un eje.',
+        correct: false,
+        explanation: 'La función principal es intercambio de trabajo, no producir calor como único efecto.'
+      },
+      {
+        id: 16,
+        type: 'tf',
+        prompt: 'Las variaciones de energía cinética y potencial suelen ser muy pequeñas y pueden despreciarse.',
+        correct: true,
+        explanation: 'Es una aproximación común en balances de energía de equipos.'
+      },
+      {
+        id: 17,
+        type: 'multi',
+        prompt: 'Ejemplos de compresores alternativos:',
+        options: ['Centrífugos', 'Tipo Roots', 'De biela y pistón', 'De diafragma', 'De flujo axial'],
+        correct: [2, 3],
+        explanation: 'Biela-pistón y diafragma son alternativos; centrífugos/axiales son turbocompresores; Roots es de lóbulos rotativos.'
+      },
+      {
+        id: 18,
+        type: 'multi',
+        prompt: 'En qué componentes se realiza trabajo para modificar el estado del fluido:',
+        options: ['Bombas', 'Compresores', 'Difusores', 'Toberas', 'Turbinas'],
+        correct: [0, 1],
+        explanation: 'Bombas/compresores consumen trabajo; la turbina entrega trabajo al eje.'
+      },
+      {
+        id: 19,
+        type: 'tf',
+        prompt: 'Los compresores aumentan la presión por transferencia de energía en forma de calor.',
+        correct: false,
+        explanation: 'El aumento de presión se logra por trabajo mecánico sobre el fluido.'
+      },
+      {
+        id: 20,
+        type: 'multi',
+        prompt: 'Aplicaciones de intercambiadores de calor:',
+        options: [
+          'Cámara de combustión',
+          'Condensador de heladera',
+          'Bomba de central térmica',
+          'Compresor de heladera',
+          'Radiador de automóvil',
+          'Evaporador de un generador de vapor',
+          'Turbina de vapor'
+        ],
+        correct: [1, 4, 5],
+        explanation: 'Condensadores, radiadores y generadores de vapor intercambian calor entre corrientes.'
+      },
+      {
+        id: 21,
+        type: 'match',
+        prompt: 'Unir cada modo con su descripción.',
+        left: [
+          'Calor entre cuerpos en contacto a distinta T.',
+          'Calor mediado por un fluido por efecto de campo de T y velocidades.',
+          'Calor por emisión/absorción de radiación electromagnética.'
+        ],
+        right: ['Conducción', 'Convección', 'Radiación'],
+        correct: [0, 1, 2],
+        explanation: 'Definiciones estándar de conducción, convección y radiación.'
+      },
+      {
+        id: 22,
+        type: 'multi',
+        prompt: 'Verdadero o falso (marca V para verdadero y F para falso).',
+        subitems: [
+          'Si un fluido es incompresible, cv = cp.',
+          'El calor específico es una propiedad extensiva.',
+          'Calor específico: calor para elevar en más de una unidad de temperatura a 1 kg.'
+        ],
+        correct: [true, false, false],
+        explanation: 'Para incompresible ideal cp≈cv; el calor específico es intensivo; la definición correcta refiere a "una unidad" de temperatura.'
+      },
+      {
+        id: 23,
+        type: 'single',
+        prompt: 'En un intercambiador de placas, ¿cómo se intercambia energía entre fluidos?',
+        options: ['Conducción y convección', 'Conducción y radiación', 'Convección y radiación', 'Solo convección', 'Conducción, convección y radiación', 'Solo radiación', 'Solo conducción'],
+        correct: 0,
+        explanation: 'Convección en cada lado y conducción a través de la placa.'
+      },
+      {
+        id: 24,
+        type: 'tf',
+        prompt: 'En un intercambiador, solo puede desperdiciarse la variación de energía potencial.',
+        correct: false,
+        explanation: 'También hay pérdidas por fricción, térmicas, etc.'
+      },
+      // 25–44: repetidos/variantes del mismo banco (con las mismas respuestas):
+      {
+        id: 25,
+        type: 'multi',
+        prompt: 'Seleccionar cuáles son los modos de transferencia de energía en termodinámica:',
+        options: ['Energía cinética', 'Trabajo', 'Energía interna', 'Entropía', 'Calor', 'Energía potencial'],
+        correct: [1, 4],
+        explanation: 'Solo trabajo y calor son modos de transferencia.'
+      },
+      {
+        id: 26,
+        type: 'multi',
+        prompt: 'Seleccionar cuáles son los modos de transferencia de calor:',
+        options: ['Convección', 'Radiación', 'Evaporación', 'Fusión', 'Conducción'],
+        correct: [0, 1, 4],
+        explanation: 'Conducción, convección y radiación.'
+      },
+      {
+        id: 27,
+        type: 'tf',
+        prompt: 'Según el convenio de signos, Q > 0 hacia el sistema y Q < 0 desde el sistema.',
+        correct: true,
+        explanation: 'Convención clásica.'
+      },
+      {
+        id: 28,
+        type: 'single',
+        prompt: 'Ciclos utilizados solo en motores de combustión externa:',
+        options: ['Ciclo Diésel', 'Ciclo Otto', 'Ciclo Rankine', 'Ciclo Brayton'],
+        correct: 2,
+        explanation: 'Rankine típico = combustión externa.'
+      },
+      {
+        id: 29,
+        type: 'match',
+        prompt: 'Emparejar principios y enunciados:',
+        left: [
+          'Intercambia trabajo y calor; acumula energía interna.',
+          'Imposible transferir calor de frío a caliente como único efecto.',
+          'Imposible convertir íntegramente el calor absorbido en trabajo en un ciclo.'
+        ],
+        right: [
+          'Principio de conservación de la energía',
+          'Formulación de Clausius',
+          'Enunciado de Kelvin–Planck'
+        ],
+        correct: [0, 1, 2],
+        explanation: '1ª Ley y dos enunciados de la 2ª Ley.'
+      },
+      {
+        id: 30,
+        type: 'multi',
+        prompt: '¿Cuáles corresponden al 2º principio de la termodinámica?',
+        options: [
+          'Q fluye de T alta a T baja.',
+          'Imposible transferir calor de frío a caliente como único efecto.',
+          'Conservación de la energía en sistemas.',
+          'Imposible convertir íntegramente el calor en trabajo en un ciclo.',
+          'Un sistema puede intercambiar W y Q.'
+        ],
+        correct: [0, 1, 3],
+        explanation: 'Direccionalidad del calor (a), Clausius (b) y Kelvin–Planck (d).'
+      },
+      {
+        id: 31,
+        type: 'tf',
+        prompt: 'El enunciado de Kelvin–Planck es: "...transferir calor de un cuerpo frío a otro más caliente como único efecto".',
+        correct: false,
+        explanation: 'Ese enunciado corresponde a Clausius; Kelvin–Planck trata sobre convertir totalmente calor en trabajo.'
+      },
+      {
+        id: 32,
+        type: 'single',
+        prompt: 'Clasificación de un motor de explosión de automóviles:',
+        options: ['Combustión externa alternativa', 'Combustión externa rotativa', 'Combustión interna alternativa', 'Combustión interna rotativa'],
+        correct: 2,
+        explanation: 'Motor de encendido por chispa: combustión interna alternativa.'
+      },
+      {
+        id: 33,
+        type: 'match',
+        prompt: 'Emparejar aplicación con clasificación (considerando configuraciones típicas):',
+        left: [
+          'Turbina de gas ciclo abierto',
+          'Turbina de gas ciclo cerrado',
+          'Motor de explosión',
+          'Máquina de vapor (turbina)'
+        ],
+        right: [
+          'Combustión interna rotativa',
+          'Combustión externa rotativa',
+          'Combustión interna alternativa',
+          'Combustión externa alternativa'
+        ],
+        correct: [0, 1, 2, 1],
+        explanation: 'Abierto: interna rotativa. Cerrado: calentamiento externo. Motor de explosión: interna alternativa. La máquina de vapor con turbina es externa rotativa.'
+      },
+      {
+        id: 34,
+        type: 'multi',
+        prompt: 'Aplicaciones del ciclo Brayton:',
+        options: ['Motor de combustión interna', 'Máquina de vapor', 'Turbina de avión', 'Turbina de vapor', 'Turbina de gas'],
+        correct: [2, 4],
+        explanation: 'Brayton rige turbinas de gas y turborreactores.'
+      },
+      {
+        id: 35,
+        type: 'single',
+        prompt: '¿Qué ciclo puede lograr la máxima eficiencia reversible?',
+        options: ['Otto', 'Diésel', 'Rankine', 'Brayton', 'Carnot'],
+        correct: 4,
+        explanation: 'Carnot fija el límite superior reversible.'
+      },
+      {
+        id: 36,
+        type: 'tf',
+        prompt: 'Existen rendimientos más altos que el ciclo de Carnot.',
+        correct: false,
+        explanation: 'Ninguna máquina térmica reversible supera a Carnot entre las mismas T.'
+      },
+      {
+        id: 37,
+        type: 'single',
+        prompt: 'Un ciclo de Carnot está compuesto por:',
+        options: [
+          'Dos procesos isotermos y dos adiabáticos',
+          'Dos isocóricos y dos adiabáticos',
+          'Dos isotermos y dos isobáricos',
+          'Dos isocóricos y dos isotermos',
+          'Dos isobáricos y dos adiabáticos'
+        ],
+        correct: 0,
+        explanation: 'Isotermos + adiabáticos.'
+      },
+      {
+        id: 38,
+        type: 'tf',
+        prompt: 'Un ciclo Ericsson reversible está formado por dos isocoras y dos isobaras.',
+        correct: false,
+        explanation: 'Ericsson ideal: compresión/expansión isotérmica y calentamiento/enfriamiento isobárico con regeneración.'
+      },
+      {
+        id: 39,
+        type: 'multi',
+        prompt: 'Restricciones en diseño y análisis de ingeniería:',
+        options: ['Costos', 'Estética final', 'Estándares de medio ambiente', 'Estándares de seguridad'],
+        correct: [0, 2, 3],
+        explanation: 'Costos, ambiente y seguridad suelen ser restricciones clave.'
+      },
+      {
+        id: 40,
+        type: 'tf',
+        prompt: 'Un flujo unidimensional es un flujo de materia que entra o sale de un volumen de control.',
+        correct: false,
+        explanation: 'Eso describe un sistema abierto; 1D refiere a cómo varían las propiedades.'
+      },
+      {
+        id: 41,
+        type: 'single',
+        prompt: '¿En qué componente disminuye la velocidad en la dirección del flujo?',
+        options: ['Difusor', 'Bomba', 'Compresor', 'Tobera', 'Intercambiador de calor'],
+        correct: 0,
+        explanation: 'El difusor reduce velocidad y eleva presión.'
+      },
+      {
+        id: 42,
+        type: 'tf',
+        prompt: 'Dispositivo donde "se produce calor" por el paso de un fluido por álabes solidarios a un eje.',
+        correct: false,
+        explanation: 'Las turbomáquinas intercambian trabajo principalmente.'
+      },
+      {
+        id: 43,
+        type: 'single',
+        prompt: 'Intercambio de energía en un intercambiador de placas:',
+        options: ['Solo Convección', 'Conducción, convección y radiación', 'Conducción y radiación', 'Convección y radiación', 'Solo conducción', 'Solo radiación', 'Conducción y convección'],
+        correct: 6,
+        explanation: 'Conducción a través de la placa y convección en los canales.'
+      },
+      {
+        id: 44,
+        type: 'tf',
+        prompt: 'En un intercambiador, solo se puede desperdiciar la variación de energía potencial.',
+        correct: false,
+        explanation: 'Hay múltiples pérdidas mecánicas y térmicas además de la potencial.'
       }
     ];
+
+    const questions = normalizeQuestions(QUESTIONS);
 
     const typeLabels = {
       single: 'Selección única',
       multi: 'Selección múltiple',
       tf: 'Verdadero / Falso',
-      match: 'Emparejar'
+      match: 'Emparejar',
+      group_tf: 'Verdadero / Falso (múltiple)'
     };
 
-    const storageKey = 'modernFrontendQuiz_v1';
+    const storageKey = 'thermoEngineeringQuiz_v1';
     let state = loadState();
     const multiDelayTimers = new Map();
 
@@ -755,6 +1169,117 @@
       renderSummary();
       updateResults();
     });
+
+    function normalizeQuestions(rawQuestions) {
+      return rawQuestions.map((raw, index) => {
+        const baseId = typeof raw.id === 'number' || typeof raw.id === 'string' ? raw.id : index + 1;
+        const questionId = `q${baseId}`;
+        const base = {
+          id: questionId,
+          type: raw.type,
+          prompt: raw.prompt ?? raw.title ?? '',
+          explanation: raw.explanation ?? '',
+          helper: raw.helper ?? null
+        };
+
+        switch (raw.type) {
+          case 'single': {
+            const options = createOptionObjects(raw.options);
+            const correctIndex = Array.isArray(raw.correct) ? raw.correct[0] : raw.correct;
+            return {
+              ...base,
+              type: 'single',
+              options,
+              correct: toStringIndex(correctIndex)
+            };
+          }
+          case 'multi': {
+            if (Array.isArray(raw.subitems)) {
+              const statements = raw.subitems.map((text, idx) => ({
+                id: `${questionId}-s${idx}`,
+                text,
+                correct: Array.isArray(raw.correct) ? Boolean(raw.correct[idx]) : Boolean(raw.correct)
+              }));
+              return {
+                ...base,
+                type: 'group_tf',
+                statements
+              };
+            }
+            const options = createOptionObjects(raw.options);
+            const correctValues = Array.isArray(raw.correct)
+              ? raw.correct.map(value => toStringIndex(value)).filter(value => value !== '')
+              : [];
+            return {
+              ...base,
+              type: 'multi',
+              options,
+              correct: correctValues
+            };
+          }
+          case 'tf': {
+            return {
+              ...base,
+              type: 'tf',
+              options: [
+                { value: 'true', label: 'Verdadero' },
+                { value: 'false', label: 'Falso' }
+              ],
+              correct: raw.correct ? 'true' : 'false'
+            };
+          }
+          case 'match': {
+            return {
+              ...base,
+              type: 'match',
+              pairs: normalizeMatchPairs(raw)
+            };
+          }
+          default: {
+            const options = createOptionObjects(raw.options);
+            const correct = Array.isArray(raw.correct)
+              ? raw.correct.map(value => toStringIndex(value)).filter(value => value !== '')
+              : toStringIndex(raw.correct);
+            return {
+              ...base,
+              options,
+              correct
+            };
+          }
+        }
+      });
+    }
+
+    function createOptionObjects(optionList) {
+      if (!Array.isArray(optionList)) {
+        return [];
+      }
+      return optionList.map((label, idx) => ({
+        value: toStringIndex(idx),
+        label
+      }));
+    }
+
+    function normalizeMatchPairs(raw) {
+      const rightOptions = Array.isArray(raw.right)
+        ? raw.right.map((label, idx) => ({ value: toStringIndex(idx), label }))
+        : [];
+      const correctIndexes = Array.isArray(raw.correct) ? raw.correct : [];
+      return Array.isArray(raw.left)
+        ? raw.left.map((leftText, idx) => ({
+            left: leftText,
+            options: rightOptions.map(option => ({ ...option })),
+            correct: toStringIndex(correctIndexes[idx])
+          }))
+        : [];
+    }
+
+    function toStringIndex(value) {
+      if (value === null || value === undefined) {
+        return '';
+      }
+      return String(value);
+    }
 
     init();
 
@@ -841,10 +1366,13 @@
 
       questionContent.innerHTML = '';
       const titleId = `${question.id}-title`;
-      const helperId = question.helper ? `${question.id}-helper` : undefined;
       const evaluation = state.evaluations[question.id];
       const storedAnswer = state.answers[question.id];
       const isLocked = Boolean(evaluation);
+
+      const promptText = question.prompt ?? question.title ?? '';
+      const helperText = question.helper ?? '';
+      const helperId = helperText ? `${question.id}-helper` : undefined;
 
       const header = document.createElement('div');
       header.className = 'question-header';
@@ -853,8 +1381,8 @@
           <span class="chip">${typeLabels[question.type] ?? 'Pregunta'}</span>
           <span class="counter">Pregunta ${state.currentIndex + 1} de ${questions.length}</span>
         </div>
-        <h2 class="question-title" id="${titleId}">${question.title}</h2>
-        ${question.helper ? `<p class="question-helper" id="${helperId}">${question.helper}</p>` : ''}
+        <h2 class="question-title" id="${titleId}">${promptText}</h2>
+        ${helperText ? `<p class="question-helper" id="${helperId}">${helperText}</p>` : ''}
       `;
       questionContent.appendChild(header);
 
@@ -914,6 +1442,67 @@
               }
               applyEvaluation(question, answer);
             });
+          }
+        });
+      } else if (question.type === 'group_tf') {
+        question.statements.forEach((statement, idx) => {
+          const row = document.createElement('div');
+          row.className = 'match-row group-tf-row';
+          row.dataset.index = String(idx);
+          row.dataset.question = question.id;
+
+          const term = document.createElement('span');
+          term.className = 'match-term';
+          term.textContent = statement.text;
+
+          const controls = document.createElement('div');
+          controls.className = 'group-tf-controls';
+
+          ['true', 'false'].forEach(value => {
+            const optionLabel = document.createElement('label');
+            optionLabel.className = 'group-tf-option';
+
+            const input = document.createElement('input');
+            input.type = 'radio';
+            input.name = `${question.id}-${idx}`;
+            input.value = value;
+
+            if (Array.isArray(storedAnswer) && storedAnswer[idx] === value) {
+              input.checked = true;
+            }
+            if (isLocked) {
+              input.disabled = true;
+            }
+
+            const text = document.createElement('span');
+            text.textContent = value === 'true' ? 'Verdadero (V)' : 'Falso (F)';
+
+            optionLabel.append(input, text);
+            controls.appendChild(optionLabel);
+
+            if (!isLocked) {
+              input.addEventListener('change', () => {
+                updateGroupTfOptionState(controls);
+                const answer = collectGroupTfAnswer(question);
+                if (!answer) {
+                  return;
+                }
+                applyEvaluation(question, answer);
+              });
+            }
+          });
+
+          const helper = document.createElement('span');
+          helper.className = 'match-answer';
+          helper.setAttribute('aria-hidden', 'true');
+
+          row.append(term, controls, helper);
+          optionsWrapper.appendChild(row);
+
+          updateGroupTfOptionState(controls);
+
+          if (isLocked) {
+            row.classList.add('is-locked');
           }
         });
       } else {
@@ -1014,6 +1603,9 @@
       if (question.type === 'multi') {
         return Array.isArray(answer) ? [...answer] : [];
       }
+      if (question.type === 'group_tf') {
+        return Array.isArray(answer) ? [...answer] : [];
+      }
       if (question.type === 'match') {
         return answer ? { ...answer } : {};
       }
@@ -1036,6 +1628,17 @@
           const expected = Array.isArray(question.correct) ? [...question.correct].sort() : [];
           const received = Array.isArray(userAnswer) ? [...userAnswer].sort() : [];
           isCorrect = expected.length === received.length && expected.every((value, idx) => value === received[idx]);
+          correctAnswers = expected;
+          break;
+        }
+        case 'group_tf': {
+          const expected = Array.isArray(question.statements)
+            ? question.statements.map(item => Boolean(item.correct))
+            : [];
+          const received = Array.isArray(userAnswer)
+            ? expected.map((_, idx) => userAnswer[idx] === 'true')
+            : [];
+          isCorrect = expected.length === received.length && expected.every((value, idx) => received[idx] === value);
           correctAnswers = expected;
           break;
         }
@@ -1073,6 +1676,53 @@
             row.classList.add('show-answer');
           }
           if (userAnswer && userAnswer[key] === expected?.value) {
+            row.classList.add('is-correct');
+          } else {
+            row.classList.add('is-incorrect');
+          }
+        });
+      } else if (question.type === 'group_tf') {
+        const rows = questionContent.querySelectorAll('.group-tf-row');
+        rows.forEach(row => {
+          const index = Number(row.dataset.index ?? -1);
+          const helper = row.querySelector('.match-answer');
+          const controls = row.querySelector('.group-tf-controls');
+          const expectedValue = correctAnswers[index] ? 'true' : 'false';
+          const selectedValue = Array.isArray(userAnswer) ? userAnswer[index] : undefined;
+
+          row.classList.add('show-answer', 'is-locked');
+
+          row.querySelectorAll('input').forEach(input => {
+            input.disabled = true;
+          });
+
+          if (controls) {
+            updateGroupTfOptionState(controls);
+          }
+
+          if (helper && correctAnswers[index] !== undefined) {
+            helper.textContent = `Correcta: ${correctAnswers[index] ? 'Verdadero' : 'Falso'}`;
+          }
+
+          const expectedOption = row.querySelector(`.group-tf-option input[value="${expectedValue}"]`);
+          if (expectedOption?.parentElement) {
+            expectedOption.parentElement.classList.remove('is-active');
+            expectedOption.parentElement.classList.add('show-correct', 'is-correct');
+          }
+
+          if (selectedValue) {
+            const selectedOption = row.querySelector(`.group-tf-option input[value="${selectedValue}"]`);
+            if (selectedOption?.parentElement) {
+              selectedOption.parentElement.classList.remove('is-active');
+              if (selectedValue === expectedValue) {
+                selectedOption.parentElement.classList.add('is-correct');
+              } else {
+                selectedOption.parentElement.classList.add('is-incorrect');
+              }
+            }
+          }
+
+          if (selectedValue === expectedValue) {
             row.classList.add('is-correct');
           } else {
             row.classList.add('is-incorrect');
@@ -1156,6 +1806,16 @@
           .map(item => `${item.left} → ${getMatchLabel(question, item.left, item.value)}`)
           .join('; ');
       }
+      if (question.type === 'group_tf') {
+        const statements = Array.isArray(question.statements) ? question.statements : [];
+        return statements
+          .map((statement, idx) => {
+            const expected = evaluation.correctAnswers?.[idx];
+            const label = expected ? 'Verdadero' : 'Falso';
+            return `${statement.text ?? `Enunciado ${idx + 1}`} → ${label}`;
+          })
+          .join('; ');
+      }
       const optionMap = new Map();
       if (Array.isArray(question.options)) {
         question.options.forEach(option => {
@@ -1172,6 +1832,33 @@
       if (!pair) return value;
       const option = pair.options.find(opt => opt.value === value);
       return option ? option.label : value;
+    }
+
+    function collectGroupTfAnswer(question) {
+      if (!question) {
+        return null;
+      }
+      const rows = questionContent.querySelectorAll(`.group-tf-row[data-question="${question.id}"]`);
+      const answer = [];
+      let filled = true;
+      rows.forEach(row => {
+        const index = Number(row.dataset.index ?? -1);
+        const checked = row.querySelector('input:checked');
+        if (!checked) {
+          filled = false;
+          return;
+        }
+        answer[index] = checked.value;
+      });
+      return filled ? answer : null;
+    }
+
+    function updateGroupTfOptionState(container) {
+      if (!container) return;
+      container.querySelectorAll('.group-tf-option').forEach(option => {
+        const input = option.querySelector('input');
+        option.classList.toggle('is-active', Boolean(input?.checked));
+      });
     }
 
     function collectMultiAnswer(questionId) {


### PR DESCRIPTION
## Summary
- reemplaza el conjunto de preguntas por el banco solicitado de 44 ítems de termodinámica y diseño
- normaliza los datos brutos para integrarlos con la lógica existente e introduce soporte para preguntas de verdadero/falso por enunciado
- ajusta estilos y textos de la interfaz para reflejar el nuevo contenido y resaltar el nuevo tipo de pregunta

## Testing
- no se ejecutaron pruebas (HTML estático)


------
https://chatgpt.com/codex/tasks/task_e_68d061b40a58832784cb512cbb7f6665