### PR TITLE
Add local user accounts and registration flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,167 @@
       font-size: 1rem;
     }
 
+    .auth-card {
+      background: rgba(255, 255, 255, 0.92);
+      border-radius: var(--radius-lg);
+      padding: 2.25rem 2rem;
+      box-shadow: var(--shadow-strong);
+      margin-bottom: 2.5rem;
+    }
+
+    .auth-card h2 {
+      margin: 0;
+      font-size: clamp(1.5rem, 2.2vw, 1.85rem);
+      letter-spacing: -0.01em;
+    }
+
+    .auth-card p {
+      margin: 0.75rem 0 0;
+      color: var(--muted);
+    }
+
+    .auth-form {
+      display: grid;
+      gap: 1rem;
+      margin-top: 1.5rem;
+    }
+
+    .form-field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .form-field label {
+      font-weight: 600;
+      color: var(--text);
+    }
+
+    .form-field input {
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      padding: 0.65rem 0.75rem;
+      font-size: 1rem;
+      background: #f8fafc;
+      transition: border 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .form-field input:focus-visible {
+      outline: 3px solid rgba(99, 102, 241, 0.28);
+      outline-offset: 2px;
+      border-color: var(--primary);
+    }
+
+    .auth-submit {
+      background: var(--primary);
+      color: #ffffff;
+      border: none;
+      border-radius: 999px;
+      padding: 0.75rem 1.5rem;
+      font-weight: 600;
+      font-size: 1rem;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+      box-shadow: 0 14px 36px -24px rgba(79, 70, 229, 0.5);
+    }
+
+    .auth-submit:hover {
+      transform: translateY(-1px);
+      background: var(--primary-dark);
+    }
+
+    .auth-submit:focus-visible {
+      outline: 3px solid rgba(99, 102, 241, 0.3);
+      outline-offset: 2px;
+    }
+
+    .auth-switch {
+      margin: 0;
+      font-size: 0.95rem;
+      color: var(--muted);
+    }
+
+    .link-btn {
+      background: none;
+      border: none;
+      color: var(--primary-dark);
+      font-weight: 600;
+      cursor: pointer;
+      padding: 0;
+      text-decoration: underline;
+    }
+
+    .link-btn:hover {
+      color: var(--primary);
+    }
+
+    .link-btn:focus-visible {
+      outline: 3px solid rgba(99, 102, 241, 0.28);
+      outline-offset: 2px;
+    }
+
+    .auth-message {
+      margin-top: 1rem;
+      font-size: 0.95rem;
+      min-height: 1.25rem;
+      color: var(--muted);
+    }
+
+    .auth-message.is-error {
+      color: var(--error);
+    }
+
+    .auth-message.is-success {
+      color: var(--success);
+    }
+
+    .user-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: rgba(255, 255, 255, 0.9);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: 0.85rem 1.2rem;
+      margin-bottom: 1.5rem;
+      box-shadow: 0 16px 36px -28px rgba(79, 70, 229, 0.2);
+    }
+
+    .user-info {
+      display: flex;
+      align-items: center;
+      gap: 0.65rem;
+      color: var(--muted);
+      font-weight: 600;
+    }
+
+    .user-icon {
+      font-size: 1.35rem;
+    }
+
+    .logout-btn {
+      background: transparent;
+      border: 1px solid var(--primary);
+      color: var(--primary-dark);
+      padding: 0.45rem 1rem;
+      border-radius: 999px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .logout-btn:hover {
+      background: var(--primary);
+      color: #ffffff;
+      transform: translateY(-1px);
+      box-shadow: 0 10px 26px -20px rgba(79, 70, 229, 0.6);
+    }
+
+    .logout-btn:focus-visible {
+      outline: 3px solid rgba(99, 102, 241, 0.28);
+      outline-offset: 2px;
+    }
+
     .layout {
       display: flex;
       gap: 1.75rem;
@@ -630,6 +791,10 @@
     }
 
     @media (max-width: 960px) {
+      .auth-card {
+        padding: 1.9rem 1.75rem;
+      }
+
       .layout {
         flex-direction: column;
       }
@@ -665,6 +830,16 @@
         padding: 1.75rem 1rem 2.5rem;
       }
 
+      .auth-card {
+        padding: 1.5rem 1.25rem;
+      }
+
+      .user-bar {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.75rem;
+      }
+
       .summary-buttons {
         grid-template-columns: repeat(auto-fit, minmax(56px, 1fr));
       }
@@ -692,34 +867,82 @@
 </head>
 <body>
   <main class="app">
-    <header class="app-header">
-      <h1>Evaluación interactiva de termodinámica y diseño de ingeniería</h1>
-      <p>Respondé las preguntas y obtené retroalimentación inmediata. Podés navegar por el resumen, y tu progreso se guardará automáticamente en este dispositivo.</p>
-    </header>
-    <div class="layout">
-      <aside class="summary-panel" aria-label="Resumen de preguntas">
-        <h2>Resumen</h2>
-        <div class="summary-buttons" id="summaryButtons"></div>
-      </aside>
-      <section class="question-card" id="questionCard" aria-live="polite">
-        <div id="questionContent"></div>
-        <div class="question-footer">
-          <button type="button" class="retry-btn" id="retryButton" hidden>Reintentar</button>
-          <div class="nav-buttons">
-            <button type="button" class="nav-btn" id="prevBtn">Anterior</button>
-            <button type="button" class="nav-btn" id="nextBtn">Siguiente</button>
-          </div>
+    <section class="auth-card" id="authSection">
+      <h2 id="authTitle">Ingresá a tu cuenta</h2>
+      <p id="authSubtitle">Registrate o iniciá sesión para guardar tu progreso y tus resultados.</p>
+      <form id="loginForm" class="auth-form" autocomplete="on">
+        <div class="form-field">
+          <label for="loginUsername">Usuario</label>
+          <input type="text" id="loginUsername" name="username" autocomplete="username" required />
         </div>
+        <div class="form-field">
+          <label for="loginPassword">Contraseña</label>
+          <input type="password" id="loginPassword" name="password" autocomplete="current-password" required />
+        </div>
+        <button type="submit" class="auth-submit">Iniciar sesión</button>
+        <p class="auth-switch">
+          ¿No tenés una cuenta?
+          <button type="button" class="link-btn" id="showRegisterBtn">Registrate</button>
+        </p>
+      </form>
+      <form id="registerForm" class="auth-form" autocomplete="off" hidden>
+        <div class="form-field">
+          <label for="registerUsername">Elegí un usuario</label>
+          <input type="text" id="registerUsername" name="username" autocomplete="username" required />
+        </div>
+        <div class="form-field">
+          <label for="registerPassword">Contraseña</label>
+          <input type="password" id="registerPassword" name="password" autocomplete="new-password" required />
+        </div>
+        <div class="form-field">
+          <label for="registerConfirm">Repetí la contraseña</label>
+          <input type="password" id="registerConfirm" name="confirmPassword" autocomplete="new-password" required />
+        </div>
+        <button type="submit" class="auth-submit">Crear cuenta</button>
+        <p class="auth-switch">
+          ¿Ya tenés usuario?
+          <button type="button" class="link-btn" id="showLoginBtn">Iniciar sesión</button>
+        </p>
+      </form>
+      <p class="auth-message" id="authMessage" role="alert"></p>
+    </section>
+    <div id="quizSection" hidden>
+      <div class="user-bar" id="userBar" hidden>
+        <div class="user-info">
+          <span class="user-icon" aria-hidden="true">👤</span>
+          <span>Sesión iniciada como <strong id="currentUserLabel"></strong></span>
+        </div>
+        <button type="button" class="logout-btn" id="logoutBtn">Cerrar sesión</button>
+      </div>
+      <header class="app-header">
+        <h1>Evaluación interactiva de termodinámica y diseño de ingeniería</h1>
+        <p>Respondé las preguntas y obtené retroalimentación inmediata. Iniciá sesión con tu usuario para que tu progreso se guarde de manera personal en este dispositivo.</p>
+      </header>
+      <div class="layout">
+        <aside class="summary-panel" aria-label="Resumen de preguntas">
+          <h2>Resumen</h2>
+          <div class="summary-buttons" id="summaryButtons"></div>
+        </aside>
+        <section class="question-card" id="questionCard" aria-live="polite">
+          <div id="questionContent"></div>
+          <div class="question-footer">
+            <button type="button" class="retry-btn" id="retryButton" hidden>Reintentar</button>
+            <div class="nav-buttons">
+              <button type="button" class="nav-btn" id="prevBtn">Anterior</button>
+              <button type="button" class="nav-btn" id="nextBtn">Siguiente</button>
+            </div>
+          </div>
+        </section>
+      </div>
+      <section class="results-card" id="resultsCard" aria-live="polite">
+        <h2>Resultados</h2>
+        <p class="score-line"><span id="scoreCount">0 / 0</span> respuestas correctas</p>
+        <p class="score-percentage" id="scorePercentage">0%</p>
+        <span class="badge" id="scoreBadge">A seguir</span>
+        <p class="resume-note">Tus respuestas quedan guardadas localmente junto a tu usuario para que puedas continuar más tarde.</p>
+        <button type="button" class="reset-btn" id="resetBtn">Reiniciar evaluación</button>
       </section>
     </div>
-    <section class="results-card" id="resultsCard" aria-live="polite">
-      <h2>Resultados</h2>
-      <p class="score-line"><span id="scoreCount">0 / 0</span> respuestas correctas</p>
-      <p class="score-percentage" id="scorePercentage">0%</p>
-      <span class="badge" id="scoreBadge">A seguir</span>
-      <p class="resume-note">Tus respuestas quedan guardadas localmente para que puedas continuar más tarde.</p>
-      <button type="button" class="reset-btn" id="resetBtn">Reiniciar evaluación</button>
-    </section>
   </main>
   <script>
     const QUESTIONS = [
@@ -1158,8 +1381,23 @@
       group_tf: 'Verdadero / Falso (múltiple)'
     };
 
-    const storageKey = 'thermoEngineeringQuiz_v1';
-    let state = loadState();
+    const USER_STORAGE_KEY = 'thermoQuizUsers_v1';
+    const LEGACY_STORAGE_KEY = 'thermoEngineeringQuiz_v1';
+    let currentUser = null;
+    let state = createDefaultState();
+
+    const authSection = document.getElementById('authSection');
+    const authTitle = document.getElementById('authTitle');
+    const authSubtitle = document.getElementById('authSubtitle');
+    const loginForm = document.getElementById('loginForm');
+    const registerForm = document.getElementById('registerForm');
+    const authMessage = document.getElementById('authMessage');
+    const showRegisterBtn = document.getElementById('showRegisterBtn');
+    const showLoginBtn = document.getElementById('showLoginBtn');
+    const quizSection = document.getElementById('quizSection');
+    const userBar = document.getElementById('userBar');
+    const currentUserLabel = document.getElementById('currentUserLabel');
+    const logoutBtn = document.getElementById('logoutBtn');
 
     const summaryContainer = document.getElementById('summaryButtons');
     const questionContent = document.getElementById('questionContent');
@@ -1171,11 +1409,51 @@
     const scorePercentageEl = document.getElementById('scorePercentage');
     const scoreBadgeEl = document.getElementById('scoreBadge');
 
+    if (showRegisterBtn) {
+      showRegisterBtn.addEventListener('click', () => {
+        toggleAuthMode('register');
+      });
+    }
+
+    if (showLoginBtn) {
+      showLoginBtn.addEventListener('click', () => {
+        toggleAuthMode('login');
+      });
+    }
+
+    if (loginForm) {
+      loginForm.addEventListener('submit', async event => {
+        event.preventDefault();
+        await handleLogin();
+      });
+    }
+
+    if (registerForm) {
+      registerForm.addEventListener('submit', async event => {
+        event.preventDefault();
+        await handleRegister();
+      });
+    }
+
+    if (logoutBtn) {
+      logoutBtn.addEventListener('click', () => {
+        handleLogout();
+      });
+    }
+
     prevBtn.addEventListener('click', () => {
+      if (!currentUser) return;
       goToQuestion(state.currentIndex - 1);
     });
 
     nextBtn.addEventListener('click', () => {
+      if (!currentUser) {
+        toggleAuthMode('login');
+        showQuizSection(false);
+        showAuthSection(true);
+        showAuthMessage('Iniciá sesión o registrate para continuar con la evaluación.', 'error');
+        return;
+      }
       const question = questions[state.currentIndex];
       if (!question) {
         return;
@@ -1202,6 +1480,7 @@
     });
 
     retryButton.addEventListener('click', () => {
+      if (!currentUser) return;
       const question = questions[state.currentIndex];
       delete state.answers[question.id];
       delete state.evaluations[question.id];
@@ -1213,8 +1492,287 @@
 
     if (resetBtn) {
       resetBtn.addEventListener('click', () => {
+        if (!currentUser) {
+          toggleAuthMode('login');
+          showAuthSection(true);
+          showQuizSection(false);
+          showAuthMessage('Iniciá sesión para reiniciar la evaluación.', 'error');
+          return;
+        }
         resetQuiz();
       });
+    }
+
+    initializeAuth();
+
+    function initializeAuth() {
+      toggleAuthMode('login');
+      if (loginForm) {
+        loginForm.reset();
+      }
+      if (registerForm) {
+        registerForm.reset();
+      }
+      const database = loadUserDatabase();
+      const storedUser = database.currentUser;
+      if (storedUser && database.users?.[storedUser]) {
+        enterQuiz(storedUser, database);
+        return;
+      }
+
+      currentUser = null;
+      state = createDefaultState();
+      showAuthSection(true);
+      showQuizSection(false);
+      updateUserBar();
+      clearQuizUI();
+    }
+
+    async function handleLogin() {
+      if (!loginForm) return;
+      const usernameInput = loginForm.querySelector('input[name="username"]');
+      const passwordInput = loginForm.querySelector('input[name="password"]');
+      const username = usernameInput?.value?.trim() ?? '';
+      const password = passwordInput?.value ?? '';
+
+      if (!username || !password) {
+        showAuthMessage('Completá usuario y contraseña para iniciar sesión.', 'error');
+        return;
+      }
+
+      const database = loadUserDatabase();
+      const userRecord = database.users?.[username];
+      if (!userRecord) {
+        showAuthMessage('No encontramos una cuenta con ese usuario.', 'error');
+        return;
+      }
+
+      const passwordHash = await hashPassword(password);
+      if (userRecord.passwordHash !== passwordHash) {
+        showAuthMessage('La contraseña no coincide.', 'error');
+        return;
+      }
+
+      database.currentUser = username;
+      saveUserDatabase(database);
+      loginForm.reset();
+      if (registerForm) {
+        registerForm.reset();
+      }
+      enterQuiz(username, database);
+    }
+
+    async function handleRegister() {
+      if (!registerForm) return;
+      const usernameInput = registerForm.querySelector('input[name="username"]');
+      const passwordInput = registerForm.querySelector('input[name="password"]');
+      const confirmInput = registerForm.querySelector('input[name="confirmPassword"]');
+      const username = usernameInput?.value?.trim() ?? '';
+      const password = passwordInput?.value ?? '';
+      const confirmation = confirmInput?.value ?? '';
+
+      if (username.length < 3) {
+        showAuthMessage('El usuario debe tener al menos 3 caracteres.', 'error');
+        return;
+      }
+
+      if (password.length < 4) {
+        showAuthMessage('La contraseña debe tener al menos 4 caracteres.', 'error');
+        return;
+      }
+
+      if (password !== confirmation) {
+        showAuthMessage('Las contraseñas no coinciden.', 'error');
+        return;
+      }
+
+      const database = loadUserDatabase();
+      if (database.users?.[username]) {
+        showAuthMessage('Ese usuario ya está registrado.', 'error');
+        return;
+      }
+
+      const passwordHash = await hashPassword(password);
+      const initialState = getInitialStateForNewUser(database);
+
+      database.users = database.users ?? {};
+      database.users[username] = {
+        passwordHash,
+        state: initialState
+      };
+      database.currentUser = username;
+      saveUserDatabase(database);
+
+      registerForm.reset();
+      if (loginForm) {
+        loginForm.reset();
+      }
+      enterQuiz(username, database);
+    }
+
+    function handleLogout() {
+      if (currentUser) {
+        saveState();
+      }
+      const database = loadUserDatabase();
+      if (currentUser && database.users?.[currentUser]) {
+        database.users[currentUser] = {
+          ...database.users[currentUser],
+          state: createStateSnapshot(state)
+        };
+      }
+      database.currentUser = null;
+      saveUserDatabase(database);
+
+      currentUser = null;
+      state = createDefaultState();
+      showQuizSection(false);
+      showAuthSection(true);
+      updateUserBar();
+      toggleAuthMode('login');
+      if (loginForm) {
+        loginForm.reset();
+      }
+      if (registerForm) {
+        registerForm.reset();
+      }
+      clearQuizUI();
+      showAuthMessage('Sesión cerrada. Iniciá sesión cuando quieras para continuar.', 'success');
+    }
+
+    function enterQuiz(username, database = null) {
+      currentUser = username;
+      state = loadState(username, database);
+      showAuthSection(false);
+      showQuizSection(true);
+      updateUserBar();
+      showAuthMessage('');
+      init();
+    }
+
+    function toggleAuthMode(mode) {
+      const isRegister = mode === 'register';
+      if (loginForm) {
+        loginForm.hidden = isRegister;
+      }
+      if (registerForm) {
+        registerForm.hidden = !isRegister;
+      }
+      if (authTitle) {
+        authTitle.textContent = isRegister ? 'Creá tu cuenta' : 'Ingresá a tu cuenta';
+      }
+      if (authSubtitle) {
+        authSubtitle.textContent = isRegister
+          ? 'Ingresá un usuario y contraseña para guardar tus respuestas en este dispositivo.'
+          : 'Iniciá sesión para continuar con tu progreso guardado o crear una cuenta nueva.';
+      }
+      showAuthMessage('');
+    }
+
+    function showAuthSection(show) {
+      if (authSection) {
+        authSection.hidden = !show;
+      }
+    }
+
+    function showQuizSection(show) {
+      if (quizSection) {
+        quizSection.hidden = !show;
+      }
+    }
+
+    function showAuthMessage(message, type = 'info') {
+      if (!authMessage) return;
+      authMessage.textContent = message;
+      authMessage.classList.remove('is-error', 'is-success');
+      if (type === 'error') {
+        authMessage.classList.add('is-error');
+      } else if (type === 'success') {
+        authMessage.classList.add('is-success');
+      }
+    }
+
+    function updateUserBar() {
+      if (!userBar) return;
+      if (!currentUser) {
+        userBar.hidden = true;
+        if (currentUserLabel) {
+          currentUserLabel.textContent = '';
+        }
+        return;
+      }
+      userBar.hidden = false;
+      if (currentUserLabel) {
+        currentUserLabel.textContent = currentUser;
+      }
+    }
+
+    function clearQuizUI() {
+      if (summaryContainer) {
+        summaryContainer.innerHTML = '';
+      }
+      if (questionContent) {
+        questionContent.innerHTML = '';
+      }
+      toggleRetryButton(false);
+      prevBtn.disabled = true;
+      nextBtn.disabled = true;
+      nextBtn.dataset.mode = 'check';
+      nextBtn.textContent = 'Siguiente';
+      updateResults();
+      updateNavigation();
+    }
+
+    function getInitialStateForNewUser(database) {
+      const users = database?.users ?? {};
+      const existingUsers = Object.keys(users).length;
+      if (existingUsers === 0) {
+        const legacyState = readLegacyState();
+        if (legacyState) {
+          clearLegacyState();
+          return createStateSnapshot(legacyState);
+        }
+      }
+      return createDefaultState();
+    }
+
+    function readLegacyState() {
+      try {
+        const stored = localStorage.getItem(LEGACY_STORAGE_KEY);
+        if (!stored) {
+          return null;
+        }
+        return JSON.parse(stored);
+      } catch (error) {
+        console.warn('No se pudo leer el progreso guardado previamente:', error);
+        return null;
+      }
+    }
+
+    function clearLegacyState() {
+      try {
+        localStorage.removeItem(LEGACY_STORAGE_KEY);
+      } catch (error) {
+        console.warn('No se pudo limpiar el progreso anterior:', error);
+      }
+    }
+
+    async function hashPassword(password) {
+      try {
+        if (window.crypto?.subtle && typeof TextEncoder !== 'undefined') {
+          const encoder = new TextEncoder();
+          const data = encoder.encode(password);
+          const digest = await window.crypto.subtle.digest('SHA-256', data);
+          return Array.from(new Uint8Array(digest))
+            .map(byte => byte.toString(16).padStart(2, '0'))
+            .join('');
+        }
+      } catch (error) {
+        console.warn('No se pudo generar un hash seguro, se utilizará una codificación simple.', error);
+      }
+      return Array.from(password)
+        .map(char => char.charCodeAt(0).toString(16).padStart(2, '0'))
+        .join('');
     }
 
     function normalizeQuestions(rawQuestions) {
@@ -1327,53 +1885,124 @@
       }
       return String(value);
     }
-
-    init();
-
     function init() {
+      if (!currentUser) {
+        return;
+      }
       renderSummary();
       renderQuestion();
       updateResults();
     }
 
-    function loadState() {
-      const defaultState = {
+    function loadUserDatabase() {
+      try {
+        const stored = localStorage.getItem(USER_STORAGE_KEY);
+        if (!stored) {
+          return { currentUser: null, users: {} };
+        }
+        const parsed = JSON.parse(stored);
+        const users = parsed && typeof parsed.users === 'object' && parsed.users !== null ? parsed.users : {};
+        const storedUser = typeof parsed.currentUser === 'string' ? parsed.currentUser : null;
+        return { currentUser: storedUser, users };
+      } catch (error) {
+        console.warn('No se pudo recuperar la información de usuarios:', error);
+        return { currentUser: null, users: {} };
+      }
+    }
+
+    function saveUserDatabase(database) {
+      try {
+        localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(database));
+      } catch (error) {
+        console.warn('No se pudo guardar la información de usuarios:', error);
+      }
+    }
+
+    function createDefaultState() {
+      return {
         currentIndex: 0,
         answers: {},
         evaluations: {}
       };
+    }
 
-      try {
-        const stored = localStorage.getItem(storageKey);
-        if (!stored) {
-          return defaultState;
+    function createStateSnapshot(sourceState) {
+      const baseState = sourceState ?? createDefaultState();
+      return {
+        currentIndex: clampIndex(baseState.currentIndex ?? 0),
+        answers: cloneAnswers(baseState.answers ?? {}),
+        evaluations: cloneEvaluations(baseState.evaluations ?? {})
+      };
+    }
+
+    function cloneAnswers(answers) {
+      const result = {};
+      Object.entries(answers ?? {}).forEach(([key, value]) => {
+        if (Array.isArray(value)) {
+          result[key] = [...value];
+          return;
         }
-        const parsed = JSON.parse(stored);
-        return {
-          currentIndex: clampIndex(parsed.currentIndex ?? 0),
-          answers: parsed.answers ?? {},
-          evaluations: parsed.evaluations ?? {}
+        if (value && typeof value === 'object') {
+          result[key] = { ...value };
+          return;
+        }
+        if (value !== undefined) {
+          result[key] = value;
+        }
+      });
+      return result;
+    }
+
+    function cloneEvaluations(evaluations) {
+      const result = {};
+      Object.entries(evaluations ?? {}).forEach(([key, value]) => {
+        if (!value) return;
+        const correctAnswers = Array.isArray(value.correctAnswers)
+          ? value.correctAnswers.map(item => (item && typeof item === 'object' ? { ...item } : item))
+          : [];
+        result[key] = {
+          isCorrect: Boolean(value.isCorrect),
+          correctAnswers,
+          explanation: value.explanation ?? ''
         };
-      } catch (error) {
-        console.warn('No se pudo recuperar el estado guardado:', error);
+      });
+      return result;
+    }
+
+    function loadState(username = currentUser, database = null) {
+      const defaultState = createDefaultState();
+      if (!username) {
         return defaultState;
       }
+      const sourceDatabase = database ?? loadUserDatabase();
+      const stored = sourceDatabase.users?.[username]?.state;
+      if (!stored) {
+        return defaultState;
+      }
+      return createStateSnapshot(stored);
     }
 
     function saveState() {
-      try {
-        localStorage.setItem(storageKey, JSON.stringify(state));
-      } catch (error) {
-        console.warn('No se pudo guardar el progreso:', error);
+      if (!currentUser) {
+        return;
       }
+      const database = loadUserDatabase();
+      const users = database.users ?? {};
+      const existingRecord = users[currentUser] ?? {};
+      users[currentUser] = {
+        ...existingRecord,
+        state: createStateSnapshot(state)
+      };
+      database.users = users;
+      database.currentUser = currentUser;
+      saveUserDatabase(database);
     }
 
     function resetQuiz() {
-      state = {
-        currentIndex: 0,
-        answers: {},
-        evaluations: {}
-      };
+      if (!currentUser) {
+        return;
+      }
+      state = createDefaultState();
       saveState();
       renderSummary();
       renderQuestion();
@@ -1392,6 +2021,9 @@
     }
 
     function goToQuestion(index) {
+      if (!currentUser) {
+        return;
+      }
       state.currentIndex = clampIndex(index);
       saveState();
       renderQuestion();
@@ -1400,6 +2032,9 @@
 
     function renderSummary() {
       summaryContainer.innerHTML = '';
+      if (!currentUser) {
+        return;
+      }
       questions.forEach((question, idx) => {
         const button = document.createElement('button');
         button.type = 'button';
@@ -1423,6 +2058,13 @@
     }
 
     function renderQuestion() {
+      if (!currentUser) {
+        questionContent.innerHTML = '';
+        prevBtn.disabled = true;
+        nextBtn.disabled = true;
+        toggleRetryButton(false);
+        return;
+      }
       const question = questions[state.currentIndex];
       if (!question) return;
 
@@ -1646,7 +2288,7 @@
     }
 
     function applyEvaluation(question, rawAnswer) {
-      if (!question) return;
+      if (!question || !currentUser) return;
       const storedAnswer = cloneAnswer(question, rawAnswer);
       const evaluation = evaluateQuestion(question, storedAnswer);
 
@@ -1663,7 +2305,7 @@
     }
 
     function recordAnswer(question, answer) {
-      if (!question) return;
+      if (!question || !currentUser) return;
       const key = question.id;
 
       if (answer === null) {
@@ -1882,13 +2524,23 @@
     }
 
     function updateNavigation() {
-      prevBtn.disabled = state.currentIndex === 0;
-      const question = questions[state.currentIndex];
-      if (!question) {
+      if (!currentUser) {
+        prevBtn.disabled = true;
+        nextBtn.disabled = true;
         nextBtn.dataset.mode = 'check';
         nextBtn.textContent = 'Siguiente';
         return;
       }
+
+      prevBtn.disabled = state.currentIndex === 0;
+      const question = questions[state.currentIndex];
+      if (!question) {
+        nextBtn.disabled = true;
+        nextBtn.dataset.mode = 'check';
+        nextBtn.textContent = 'Siguiente';
+        return;
+      }
+      nextBtn.disabled = false;
       const hasEvaluation = question ? Boolean(state.evaluations[question.id]) : false;
 
       if (!hasEvaluation) {
@@ -1907,6 +2559,13 @@
     }
 
     function updateResults() {
+      if (!currentUser) {
+        const total = questions.length;
+        scoreCountEl.textContent = `0 / ${total}`;
+        scorePercentageEl.textContent = '0%';
+        scoreBadgeEl.textContent = getBadgeLabel(0);
+        return;
+      }
       const evaluations = Object.values(state.evaluations);
       const correctCount = evaluations.filter(entry => entry?.isCorrect).length;
       const total = questions.length;


### PR DESCRIPTION
## Summary
- add an authentication card with login and registration forms that persist credentials and quiz state in localStorage
- track answers and evaluations per logged-in user, showing a session banner with logout controls
- update navigation, results and reset logic to work with multi-user state and migrate any legacy stored progress

## Testing
- No automated tests were run (static HTML page)


------
https://chatgpt.com/codex/tasks/task_e_68d07a6042148327bf3303d668e55c12